### PR TITLE
Adjust configuration of "Arduino Lint" workflow following Library Manager submission

### DIFF
--- a/.github/workflows/arduino-lint.yml
+++ b/.github/workflows/arduino-lint.yml
@@ -23,4 +23,4 @@ jobs:
         uses: arduino/arduino-lint-action@v1
         with:
           project-type: library
-          library-manager: submit
+          library-manager: update


### PR DESCRIPTION
The "Arduino Lint" GitHub Actions workflow checks for problems with the Arduino metadata and structure of the library.

There are different requirements depending on whether the library has been submitted to [Arduino Library Manager registry](https://github.com/arduino/library-registry). Previously the workflow was [configured as appropriate for a pre-submission library](https://github.com/arduino/arduino-lint-action#library-manager).  The library has since been submitted (https://github.com/arduino/library-registry/pull/2769), which made the configuration inappropriate and caused spurious workflow run failures:

```
ERROR: Library name 107-Arduino-Servo-RP2040 is in use by a library in the Library Manager index. Each library must have
       a unique name value. If your library is already in the index, use the "--library-manager update" flag.           
       See: https://arduino.github.io/arduino-cli/latest/library-specification/#libraryproperties-file-format           
       (Rule LP017)  
```