### PR TITLE
Enhanced Pulse Width and Angle-Based Control for Improved Arduino's Servo Compatibility

### DIFF
--- a/src/107-Arduino-Servo-RP2040.cpp
+++ b/src/107-Arduino-Servo-RP2040.cpp
@@ -92,6 +92,17 @@ void Servo::write(int value)
   writeMicroseconds(pulse_width_us);
 }
 
+void Servo::writeAngle(int angle)
+{
+  if (angle < 0)
+    angle = 0;
+  else if (angle > _max_angle)
+    angle = _max_angle;
+
+  uint16_t pulse_width_us = map(angle, 0, _max_angle, _min_pulse_width_us, _max_pulse_width_us);
+  writeMicroseconds(pulse_width_us);
+}
+
 /**************************************************************************************
  * NAMESPACE
  **************************************************************************************/

--- a/src/107-Arduino-Servo-RP2040.cpp
+++ b/src/107-Arduino-Servo-RP2040.cpp
@@ -81,6 +81,9 @@ void Servo::writeMicroseconds(uint16_t const pulse_width_us)
 
 void Servo::write(int const value)
 {
+  if (!_is_attached)
+    return;
+
   int clamped = value;
   clamped = max(0, clamped);
   clamped = min(180, clamped);
@@ -91,6 +94,9 @@ void Servo::write(int const value)
 
 void Servo::writeAngle(int const angle)
 {
+  if (!_is_attached)
+    return;
+
   int clamped = angle;
   clamped = max(0, clamped);
   clamped = min(_max_angle, clamped);

--- a/src/107-Arduino-Servo-RP2040.cpp
+++ b/src/107-Arduino-Servo-RP2040.cpp
@@ -80,15 +80,15 @@ void Servo::writeMicroseconds(uint16_t const pulse_width_us)
   pwm_set_chan_level(_slice_num, _channel, pulse_width_us);
 }
 
-void Servo::write(int angle)
+void Servo::write(int value)
 {
-  if (angle < 0)
-    angle = 0;
+  if (value < 0)
+    value = 0;
 
-  if (angle > 180)
-    angle = 180;
+  if (value > 180)
+    value = 180;
 
-  uint16_t pulse_width_us = map(angle, 0, 180, _min_pulse_width_us, _max_pulse_width_us);
+  uint16_t pulse_width_us = map(value, 0, 180, _min_pulse_width_us, _max_pulse_width_us);
   writeMicroseconds(pulse_width_us);
 }
 

--- a/src/107-Arduino-Servo-RP2040.cpp
+++ b/src/107-Arduino-Servo-RP2040.cpp
@@ -27,16 +27,22 @@ namespace _107_
 
 void Servo::attach(pin_size_t const pin)
 {
-  attach(pin, DEFAULT_MIN_PULSE_WIDTH_us, DEFAULT_MAX_PULSE_WIDTH_us);
+  attach(pin, DEFAULT_MIN_PULSE_WIDTH_us, DEFAULT_MAX_PULSE_WIDTH_us, DEFAULT_MAX_ANGLE);
 }
 
 void Servo::attach(pin_size_t const pin, uint16_t const min_pulse_width_us, uint16_t const max_pulse_width_us)
+{
+  attach(pin, min_pulse_width_us, max_pulse_width_us, DEFAULT_MAX_ANGLE);
+}
+
+void Servo::attach(pin_size_t const pin, uint16_t min_pulse_width_us, uint16_t max_pulse_width_us, uint16_t max_angle)
 {
   if (_is_attached)
     return;
 
   _min_pulse_width_us = min_pulse_width_us;
   _max_pulse_width_us = max_pulse_width_us;
+  _max_angle = max_angle;
 
   _slice_num = pwm_gpio_to_slice_num(pin);
   _channel = pwm_gpio_to_channel(pin);

--- a/src/107-Arduino-Servo-RP2040.cpp
+++ b/src/107-Arduino-Servo-RP2040.cpp
@@ -79,7 +79,7 @@ void Servo::writeMicroseconds(uint16_t const pulse_width_us)
   pwm_set_chan_level(_slice_num, _channel, pulse_width_us);
 }
 
-void Servo::write(int value)
+void Servo::write(int const value)
 {
   if (value < 0)
     value = 0;
@@ -87,7 +87,7 @@ void Servo::write(int value)
   if (value > 180)
     value = 180;
 
-  uint16_t pulse_width_us = map(value, 0, 180, _min_pulse_width_us, _max_pulse_width_us);
+  uint16_t const pulse_width_us = map(value, 0, 180, _min_pulse_width_us, _max_pulse_width_us);
   writeMicroseconds(pulse_width_us);
 }
 
@@ -98,7 +98,7 @@ void Servo::writeAngle(int angle)
   else if (angle > _max_angle)
     angle = _max_angle;
 
-  uint16_t pulse_width_us = map(angle, 0, _max_angle, _min_pulse_width_us, _max_pulse_width_us);
+  uint16_t const pulse_width_us = map(angle, 0, _max_angle, _min_pulse_width_us, _max_pulse_width_us);
   writeMicroseconds(pulse_width_us);
 }
 

--- a/src/107-Arduino-Servo-RP2040.cpp
+++ b/src/107-Arduino-Servo-RP2040.cpp
@@ -60,7 +60,7 @@ void Servo::attach(pin_size_t const pin, uint16_t const min_pulse_width_us, uint
   _is_attached = true;
 }
 
-void Servo::setMaxAngle(uint16_t const max_angle)
+void Servo::setMaxAngle(int const max_angle)
 {
   _max_angle = max_angle;
 }

--- a/src/107-Arduino-Servo-RP2040.cpp
+++ b/src/107-Arduino-Servo-RP2040.cpp
@@ -78,7 +78,7 @@ void Servo::write(int angle)
 {
   if (angle < 0)
     angle = 0;
-  
+
   if (angle > 180)
     angle = 180;
 

--- a/src/107-Arduino-Servo-RP2040.cpp
+++ b/src/107-Arduino-Servo-RP2040.cpp
@@ -91,10 +91,11 @@ void Servo::write(int const value)
   writeMicroseconds(pulse_width_us);
 }
 
-void Servo::writeAngle(int angle)
+void Servo::writeAngle(int const angle)
 {
   if (angle < 0)
     angle = 0;
+
   else if (angle > _max_angle)
     angle = _max_angle;
 

--- a/src/107-Arduino-Servo-RP2040.cpp
+++ b/src/107-Arduino-Servo-RP2040.cpp
@@ -74,6 +74,18 @@ void Servo::writeMicroseconds(uint16_t const pulse_width_us)
   pwm_set_chan_level(_slice_num, _channel, pulse_width_us);
 }
 
+void Servo::write(int angle)
+{
+  if (angle < 0)
+    angle = 0;
+  
+  if (angle > 180)
+    angle = 180;
+
+  uint16_t pulse_width_us = map(angle, 0, 180, _min_pulse_width_us, _max_pulse_width_us);
+  writeMicroseconds(pulse_width_us);
+}
+
 /**************************************************************************************
  * NAMESPACE
  **************************************************************************************/

--- a/src/107-Arduino-Servo-RP2040.cpp
+++ b/src/107-Arduino-Servo-RP2040.cpp
@@ -27,8 +27,16 @@ namespace _107_
 
 void Servo::attach(pin_size_t const pin)
 {
+  attach(pin, DEFAULT_MIN_PULSE_WIDTH_us, DEFAULT_MAX_PULSE_WIDTH_us);
+}
+
+void Servo::attach(pin_size_t const pin, uint16_t min_pulse_width_us, uint16_t max_pulse_width_us)
+{
   if (_is_attached)
     return;
+
+  _min_pulse_width_us = min_pulse_width_us;
+  _max_pulse_width_us = max_pulse_width_us;
 
   _slice_num = pwm_gpio_to_slice_num(pin);
   _channel = pwm_gpio_to_channel(pin);

--- a/src/107-Arduino-Servo-RP2040.cpp
+++ b/src/107-Arduino-Servo-RP2040.cpp
@@ -81,25 +81,21 @@ void Servo::writeMicroseconds(uint16_t const pulse_width_us)
 
 void Servo::write(int const value)
 {
-  if (value < 0)
-    value = 0;
+  int clamped = value;
+  clamped = max(0, clamped);
+  clamped = min(180, clamped);
 
-  if (value > 180)
-    value = 180;
-
-  uint16_t const pulse_width_us = map(value, 0, 180, _min_pulse_width_us, _max_pulse_width_us);
+  uint16_t const pulse_width_us = map(clamped, 0, 180, _min_pulse_width_us, _max_pulse_width_us);
   writeMicroseconds(pulse_width_us);
 }
 
 void Servo::writeAngle(int const angle)
 {
-  if (angle < 0)
-    angle = 0;
+  int clamped = angle;
+  clamped = max(0, clamped);
+  clamped = min(_max_angle, clamped);
 
-  else if (angle > _max_angle)
-    angle = _max_angle;
-
-  uint16_t const pulse_width_us = map(angle, 0, _max_angle, _min_pulse_width_us, _max_pulse_width_us);
+  uint16_t const pulse_width_us = map(clamped, 0, _max_angle, _min_pulse_width_us, _max_pulse_width_us);
   writeMicroseconds(pulse_width_us);
 }
 

--- a/src/107-Arduino-Servo-RP2040.cpp
+++ b/src/107-Arduino-Servo-RP2040.cpp
@@ -30,7 +30,7 @@ void Servo::attach(pin_size_t const pin)
   attach(pin, DEFAULT_MIN_PULSE_WIDTH_us, DEFAULT_MAX_PULSE_WIDTH_us);
 }
 
-void Servo::attach(pin_size_t const pin, uint16_t min_pulse_width_us, uint16_t max_pulse_width_us)
+void Servo::attach(pin_size_t const pin, uint16_t const min_pulse_width_us, uint16_t const max_pulse_width_us)
 {
   if (_is_attached)
     return;

--- a/src/107-Arduino-Servo-RP2040.cpp
+++ b/src/107-Arduino-Servo-RP2040.cpp
@@ -27,22 +27,16 @@ namespace _107_
 
 void Servo::attach(pin_size_t const pin)
 {
-  attach(pin, DEFAULT_MIN_PULSE_WIDTH_us, DEFAULT_MAX_PULSE_WIDTH_us, DEFAULT_MAX_ANGLE);
+  attach(pin, DEFAULT_MIN_PULSE_WIDTH_us, DEFAULT_MAX_PULSE_WIDTH_us);
 }
 
 void Servo::attach(pin_size_t const pin, uint16_t const min_pulse_width_us, uint16_t const max_pulse_width_us)
-{
-  attach(pin, min_pulse_width_us, max_pulse_width_us, DEFAULT_MAX_ANGLE);
-}
-
-void Servo::attach(pin_size_t const pin, uint16_t min_pulse_width_us, uint16_t max_pulse_width_us, uint16_t max_angle)
 {
   if (_is_attached)
     return;
 
   _min_pulse_width_us = min_pulse_width_us;
   _max_pulse_width_us = max_pulse_width_us;
-  _max_angle = max_angle;
 
   _slice_num = pwm_gpio_to_slice_num(pin);
   _channel = pwm_gpio_to_channel(pin);
@@ -64,6 +58,11 @@ void Servo::attach(pin_size_t const pin, uint16_t min_pulse_width_us, uint16_t m
   gpio_set_function(pin, GPIO_FUNC_PWM);
 
   _is_attached = true;
+}
+
+void Servo::setMaxAngle(uint16_t const max_angle)
+{
+  _max_angle = max_angle;
 }
 
 void Servo::writeMicroseconds(uint16_t const pulse_width_us)

--- a/src/107-Arduino-Servo-RP2040.h
+++ b/src/107-Arduino-Servo-RP2040.h
@@ -32,7 +32,7 @@ public:
   static uint16_t constexpr DEFAULT_MIN_PULSE_WIDTH_us     = 1000;
   static uint16_t constexpr DEFAULT_MAX_PULSE_WIDTH_us     = 2000;
   static uint16_t constexpr DEFAULT_NEUTRAL_PULSE_WIDTH_us = 1500;
-  static uint16_t constexpr DEFAULT_MAX_ANGLE              = 180;
+  static int constexpr DEFAULT_MAX_ANGLE                   = 180;
 
   static uint16_t constexpr PWM_PERIOD_us = 20*1000UL;
 
@@ -48,13 +48,14 @@ public:
 
   void attach(pin_size_t const pin);
   void attach(pin_size_t const pin, uint16_t min_pulse_width_us, uint16_t max_pulse_width_us);
-  void setMaxAngle(uint16_t const max_angle);
+  void setMaxAngle(int const max_angle);
   void writeMicroseconds(uint16_t const pulse_width_us);
   void write(int value);
   void writeAngle(int angle);
 
 private:
-  uint16_t _min_pulse_width_us, _max_pulse_width_us, _neutral_pulse_width_us, _max_angle;
+  uint16_t _min_pulse_width_us, _max_pulse_width_us, _neutral_pulse_width_us;
+  int _max_angle;
   bool _is_attached;
   uint8_t _slice_num, _channel;
 };

--- a/src/107-Arduino-Servo-RP2040.h
+++ b/src/107-Arduino-Servo-RP2040.h
@@ -48,6 +48,7 @@ public:
 
   void attach(pin_size_t const pin);
   void attach(pin_size_t const pin, uint16_t min_pulse_width_us, uint16_t max_pulse_width_us);
+  void attach(pin_size_t const pin, uint16_t min_pulse_width_us, uint16_t max_pulse_width_us, uint16_t max_angle);
   void writeMicroseconds(uint16_t const pulse_width_us);
   void write(int angle);
 

--- a/src/107-Arduino-Servo-RP2040.h
+++ b/src/107-Arduino-Servo-RP2040.h
@@ -51,6 +51,7 @@ public:
   void attach(pin_size_t const pin, uint16_t min_pulse_width_us, uint16_t max_pulse_width_us, uint16_t max_angle);
   void writeMicroseconds(uint16_t const pulse_width_us);
   void write(int value);
+  void writeAngle(int angle);
 
 private:
   uint16_t _min_pulse_width_us, _max_pulse_width_us, _neutral_pulse_width_us, _max_angle;

--- a/src/107-Arduino-Servo-RP2040.h
+++ b/src/107-Arduino-Servo-RP2040.h
@@ -32,6 +32,7 @@ public:
   static uint16_t constexpr DEFAULT_MIN_PULSE_WIDTH_us     = 1000;
   static uint16_t constexpr DEFAULT_MAX_PULSE_WIDTH_us     = 2000;
   static uint16_t constexpr DEFAULT_NEUTRAL_PULSE_WIDTH_us = 1500;
+  static uint16_t constexpr DEFAULT_MAX_ANGLE              = 180;
 
   static uint16_t constexpr PWM_PERIOD_us = 20*1000UL;
 
@@ -39,6 +40,7 @@ public:
   : _min_pulse_width_us{DEFAULT_MIN_PULSE_WIDTH_us}
   , _max_pulse_width_us{DEFAULT_MAX_PULSE_WIDTH_us}
   , _neutral_pulse_width_us{DEFAULT_NEUTRAL_PULSE_WIDTH_us}
+  , _max_angle{DEFAULT_MAX_ANGLE}
   , _is_attached{false}
   , _slice_num{0}
   , _channel{0}
@@ -50,7 +52,7 @@ public:
   void write(int angle);
 
 private:
-  uint16_t _min_pulse_width_us, _max_pulse_width_us, _neutral_pulse_width_us;
+  uint16_t _min_pulse_width_us, _max_pulse_width_us, _neutral_pulse_width_us, _max_angle;
   bool _is_attached;
   uint8_t _slice_num, _channel;
 };

--- a/src/107-Arduino-Servo-RP2040.h
+++ b/src/107-Arduino-Servo-RP2040.h
@@ -50,8 +50,8 @@ public:
   void attach(pin_size_t const pin, uint16_t min_pulse_width_us, uint16_t max_pulse_width_us);
   void setMaxAngle(int const max_angle);
   void writeMicroseconds(uint16_t const pulse_width_us);
-  void write(int value);
-  void writeAngle(int angle);
+  void write(int const value);
+  void writeAngle(int const angle);
 
 private:
   uint16_t _min_pulse_width_us, _max_pulse_width_us, _neutral_pulse_width_us;

--- a/src/107-Arduino-Servo-RP2040.h
+++ b/src/107-Arduino-Servo-RP2040.h
@@ -50,7 +50,7 @@ public:
   void attach(pin_size_t const pin, uint16_t min_pulse_width_us, uint16_t max_pulse_width_us);
   void attach(pin_size_t const pin, uint16_t min_pulse_width_us, uint16_t max_pulse_width_us, uint16_t max_angle);
   void writeMicroseconds(uint16_t const pulse_width_us);
-  void write(int angle);
+  void write(int value);
 
 private:
   uint16_t _min_pulse_width_us, _max_pulse_width_us, _neutral_pulse_width_us, _max_angle;

--- a/src/107-Arduino-Servo-RP2040.h
+++ b/src/107-Arduino-Servo-RP2040.h
@@ -48,7 +48,7 @@ public:
 
   void attach(pin_size_t const pin);
   void attach(pin_size_t const pin, uint16_t min_pulse_width_us, uint16_t max_pulse_width_us);
-  void attach(pin_size_t const pin, uint16_t min_pulse_width_us, uint16_t max_pulse_width_us, uint16_t max_angle);
+  void setMaxAngle(uint16_t const max_angle);
   void writeMicroseconds(uint16_t const pulse_width_us);
   void write(int value);
   void writeAngle(int angle);

--- a/src/107-Arduino-Servo-RP2040.h
+++ b/src/107-Arduino-Servo-RP2040.h
@@ -45,10 +45,12 @@ public:
   { }
 
   void attach(pin_size_t const pin);
+  void attach(pin_size_t const pin, uint16_t min_pulse_width_us, uint16_t max_pulse_width_us);
   void writeMicroseconds(uint16_t const pulse_width_us);
+  void write(int angle);
 
 private:
-  uint16_t const _min_pulse_width_us, _max_pulse_width_us, _neutral_pulse_width_us;
+  uint16_t _min_pulse_width_us, _max_pulse_width_us, _neutral_pulse_width_us;
   bool _is_attached;
   uint8_t _slice_num, _channel;
 };


### PR DESCRIPTION
I've found this library to be incredibly useful, especially since other popular libraries like Adafruit_NeoPixel also utilize PIO, resulting in conflicts with Servo functionality. I appreciate the effort put into its development.

The purpose of this pull request is to align the public methods of `_107_::Servo` more closely with those found in the Arduino environment, enhancing usability and compatibility.

- The SG90 is a commonly used servo motor, yet it operates within different minimum and maximum pulse widths compared to the default values currently set in the library. To accommodate this, I propose overloading the `attach` method to allow these values to be configurable.
- While the `writeMicroseconds` method is undoubtedly useful, the addition of a simpler `write` method would further streamline the user experience by mapping the 0-180 degree range directly to the minimum and maximum pulse widths.

My testing with the SG90 servo I possess has been somewhat limited, so I highly recommend a thorough review of these changes.

Thank you for considering this pull request and for your dedication to improving this library.